### PR TITLE
Remove the 5.0 strings from the README so the file is more version agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## -*- docker-image-name: "actian/vector:community" -*-
 #-------------------------------------------------------------------------------
 
 # Copyright 2017 Actian Corporation
@@ -54,10 +55,10 @@ EXPOSE 27832 27839 44223 16902
 
 # Give the actian user a database password to allow for access from outside the container
 # Only uncomment this line if you want to allow this
-# An alternative, and more secure technique is to do this after the image is created and commit the resulting container. 
+# An alternative, and more secure technique is to do this after the image is created and commit the resulting container.
 # That way, the real password isn't embedded in a Dockerfile
-# 	docker exec -u actian -it vector bash -i -c 'echo "alter user actian with password =actian;commit;\\p\\g"|sql iidbdb'
-#	docker commit vector actian/vector:latest
+#       docker exec -u actian -it vector bash -i -c 'echo "alter user actian with password =actian;commit;\\p\\g"|sql iidbdb'
+#       docker commit vector actian/vector:latest
 # RUN sudo su - actian -c 'ingstart >/tmp/ingstart.out;echo "alter user actian with password =actian;commit;\\p\\g" | sql iidbdb>/tmp/pw.out;ingstop -force >/tmp/ingstop.out||true'
 
 # Allow external locations - uncomment to make these available for use

--- a/README.md
+++ b/README.md
@@ -10,29 +10,29 @@ if you haven't already done so, download and install Docker and Kitematic (optio
 
 From a command prompt in this folder (e.g. Shift-Right click the folder name in Windows and select 'Command Prompt Here'), run the following command:
 
-  `docker build -t actian/vector5.0:community .`
+	`docker build -t actian/vector:community .`
 
 which will download a minimal Centos 7 machine image, then install Actian Vector into this. If all goes well, a new image will be created which you can see via
 
-   `docker images`
+	`docker images`
 
 To create a new container based on this image, type:
 
-  `docker run --name vector actian/vector:community`
+	`docker run --name vector actian/vector:community`
 
 and a new container will be created, and Vector will be started. Running the container this way will show you the Vector startup log details, and then pause, requiring you to hit Ctrl-C at the end before you can log into the container. Alternatively, starting the container via:
 
-  `docker run --name vector -d actian/vector5.0:community`
+	`docker run --name vector -d actian/vector:community`
 
 with the -d for 'daemon' flag will return control to the command-line immediately, and will not print startup details onto standard out - these can be seen via Docker logs or through Kitematic instead, if needed.
 
 To log into the running container, use:
 
-  `docker exec -it vector bash`
+	`docker exec -it vector bash`
 
 If you want to expose the Vector instance inside this machine to allow external access from outside the container, e.g. via Actian Director, or Tableau, or other BI tool, you need to explicitly map the ports that are exposed by the container to ports on the host machine. To do this, change the above docker run command to:
 
-  `docker run --name vector -d actian/vector5.0:community -p 27832:27832 -p 27839:27839 -p 44223:44223 -p 16902:16902`
+	`docker run --name vector -d actian/vector:community -p 27832:27832 -p 27839:27839 -p 44223:44223 -p 16902:16902`
 
 if you want to allow access via ODBC, JDBC, .Net, Ingres/Net, and Actian Director.
 


### PR DESCRIPTION
Remove the 5.0 strings from the README so the file is more version agnostic
Clean up some indenting just because.
Add a meta-tag comment to the Dockerfile defining the default image name for IDEs that support that type of thing